### PR TITLE
Add bounds checking on VIDEO register (+warning)

### DIFF
--- a/machine/machine.c
+++ b/machine/machine.c
@@ -183,6 +183,10 @@ void display_machine()
 		palette = &default_palette[0];
 
 	uint8_t vramblock = read6502(0x100);
+	if (vramblock > 0xf) {
+		printf("VIDEO register out of valid range ($%x), constraining to to $0-$f.\n", vramblock);
+		vramblock = vramblock & 0x10;
+	}
 	uint8_t *vram = &memory[vramblock*4096];
 	uint8_t byt;
 


### PR DESCRIPTION
This is to prevent accessing invalid emulator RAM and causing an emulator crash when ASM (intentionally or unintentionally) writes values greater than $f to $0100.